### PR TITLE
TECH-2705 - Allow setting ingressClassName for all ingreses

### DIFF
--- a/charts/graphprotocol-node/Chart.yaml
+++ b/charts/graphprotocol-node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: graphprotocol-node
 description: A Helm chart for Graph Protocol Nodes
 type: application
-version: 0.1.21
+version: 0.1.22
 keywords:
   - graphprotocol
   - ethereum

--- a/charts/graphprotocol-node/templates/ingress.yaml
+++ b/charts/graphprotocol-node/templates/ingress.yaml
@@ -10,6 +10,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
@@ -30,7 +33,7 @@ spec:
             backend:
               service:
                 name: {{ include "graphprotocol-node.fullname" $ }}
-                port: 
+                port:
                   number: 8000
     {{- end }}
 {{- end }}
@@ -47,6 +50,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.ingressRpc.ingressClassName }}
+  ingressClassName: {{ .Values.ingressRpc.ingressClassName }}
+  {{- end }}
   {{- if .Values.ingressRpc.tls }}
   tls:
     {{- range .Values.ingressRpc.tls }}
@@ -67,7 +73,7 @@ spec:
             backend:
               service:
                 name: {{ include "graphprotocol-node.fullname" $ }}
-                port: 
+                port:
                   number: 8020
     {{- end }}
 {{- end }}
@@ -84,6 +90,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.ingressWebsocket.ingressClassName }}
+  ingressClassName: {{ .Values.ingressWebsocket.ingressClassName }}
+  {{- end }}
   {{- if .Values.ingressWebsocket.tls }}
   tls:
     {{- range .Values.ingressWebsocket.tls }}
@@ -104,11 +113,10 @@ spec:
             backend:
               service:
                 name: {{ include "graphprotocol-node.fullname" $ }}
-                port: 
+                port:
                   number: 8001
     {{- end }}
 {{- end }}
-
 ---
 {{- if .Values.ingressIndex.enabled -}}
 apiVersion: networking.k8s.io/v1
@@ -122,6 +130,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.ingressIndex.ingressClassName }}
+  ingressClassName: {{ .Values.ingressIndex.ingressClassName }}
+  {{- end }}
   {{- if .Values.ingressIndex.tls }}
   tls:
     {{- range .Values.ingressIndex.tls }}
@@ -142,7 +153,7 @@ spec:
             backend:
               service:
                 name: {{ include "graphprotocol-node.fullname" $ }}
-                port: 
+                port:
                   number: 8030
     {{- end }}
 {{- end }}

--- a/charts/graphprotocol-node/values.yaml
+++ b/charts/graphprotocol-node/values.yaml
@@ -88,6 +88,7 @@ monitoring:
 
 ingress:
   enabled: false
+  # ingressClassName: traefik # could also be nginx or whatever else, depending on the ingress controller used by the cluster
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
@@ -100,6 +101,7 @@ ingress:
 
 ingressRpc:
   enabled: false
+  # ingressClassName: traefik # could also be nginx or whatever else, depending on the ingress controller used by the cluster
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
@@ -112,6 +114,7 @@ ingressRpc:
 
 ingressIndex:
   enabled: false
+  # ingressClassName: traefik # could also be nginx or whatever else, depending on the ingress controller used by the cluster
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
@@ -124,6 +127,7 @@ ingressIndex:
 
 ingressWebsocket:
   enabled: false
+  # ingressClassName: traefik # could also be nginx or whatever else, depending on the ingress controller used by the cluster
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
`kubernetes.io/ingress.class` has been deprecated with Kubernetes v1.22, so that's one reason to use `ingressClassName`, which was was introduced in v1.18 (according to [this](https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation)).
The other reason to do this is to keep it consistent with the `common` chart, which also uses `ingressClassName`. For backwards compatibility, I've added this inside a conditional statement.