### PR TITLE
TECH-2705 - Add TLS management per ingress

### DIFF
--- a/charts/graphprotocol-node/Chart.yaml
+++ b/charts/graphprotocol-node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: graphprotocol-node
 description: A Helm chart for Graph Protocol Nodes
 type: application
-version: 0.1.22
+version: 0.1.23
 keywords:
   - graphprotocol
   - ethereum
@@ -12,4 +12,4 @@ sources:
 maintainers:
   - email: dm3ch@dm3ch.net
     name: dm3ch (original author)
-appVersion: v0.27.0
+appVersion: v0.33.0

--- a/charts/graphprotocol-node/templates/certificate.yaml
+++ b/charts/graphprotocol-node/templates/certificate.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.ingress.tls.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.ingress.host }}
+spec:
+  secretName: {{ .Values.ingress.host }}-tls
+  duration: 2160h
+  renewBefore: 2158h
+  issuerRef:
+    name: {{ .Values.ingress.tls.issuerName }}
+    kind: ClusterIssuer
+  dnsNames:
+  {{- range .Values.ingress.hosts }}
+    - {{ . | quote }}
+  {{- end }}
+{{- end }}
+---
+{{- if .Values.ingressIndex.tls.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.ingressIndex.host }}
+spec:
+  secretName: {{ .Values.ingressIndex.host }}-tls
+  duration: 2160h
+  renewBefore: 2158h
+  issuerRef:
+    name: {{ .Values.ingressIndex.tls.issuerName }}
+    kind: ClusterIssuer
+  dnsNames:
+  {{- range .Values.ingressIndex.hosts }}
+    - {{ . | quote }}
+  {{- end }}
+{{- end }}
+---
+{{- if .Values.ingressRpc.tls.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.ingressRpc.host }}
+spec:
+  secretName: {{ .Values.ingressRpc.host }}-tls
+  duration: 2160h
+  renewBefore: 2158h
+  issuerRef:
+    name: {{ .Values.ingressRpc.tls.issuerName }}
+    kind: ClusterIssuer
+  dnsNames:
+  {{- range .Values.ingressRpc.hosts }}
+    - {{ . | quote }}
+  {{- end }}
+{{- end }}
+---
+{{- if .Values.ingressWebsocket.tls.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.ingressWebsocket.host }}
+spec:
+  secretName: {{ .Values.ingressWebsocket.host }}-tls
+  duration: 2160h
+  renewBefore: 2158h
+  issuerRef:
+    name: {{ .Values.ingressWebsocket.tls.issuerName }}
+    kind: ClusterIssuer
+  dnsNames:
+  {{- range .Values.ingressWebsocket.hosts }}
+    - {{ . | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/graphprotocol-node/templates/ingress.yaml
+++ b/charts/graphprotocol-node/templates/ingress.yaml
@@ -1,8 +1,9 @@
+{{- $fullName := include "graphprotocol-node.fullname" . -}}
 {{- if .Values.ingress.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "graphprotocol-node.fullname" . }}
+  name: {{ $fullName }}
   labels:
     {{- include "graphprotocol-node.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
@@ -13,15 +14,13 @@ spec:
   {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName }}
   {{- end }}
-  {{- if .Values.ingress.tls }}
+  {{- if .Values.ingress.tls.enabled }}
   tls:
-    {{- range .Values.ingress.tls }}
     - hosts:
-        {{- range .hosts }}
+      {{- range .Values.ingress.hosts }}
         - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
+      {{- end }}
+      secretName: {{ $fullName }}-tls
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
@@ -32,7 +31,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ include "graphprotocol-node.fullname" $ }}
+                name: {{ $fullName }}
                 port:
                   number: 8000
     {{- end }}
@@ -42,7 +41,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "graphprotocol-node.fullname" . }}-rpc
+  name: {{ $fullName }}-rpc
   labels:
     {{- include "graphprotocol-node.labels" . | nindent 4 }}
   {{- with .Values.ingressRpc.annotations }}
@@ -53,15 +52,13 @@ spec:
   {{- if .Values.ingressRpc.ingressClassName }}
   ingressClassName: {{ .Values.ingressRpc.ingressClassName }}
   {{- end }}
-  {{- if .Values.ingressRpc.tls }}
+  {{- if .Values.ingressRpc.tls.enabled }}
   tls:
-    {{- range .Values.ingressRpc.tls }}
     - hosts:
-        {{- range .hosts }}
+      {{- range .Values.ingressRpc.hosts }}
         - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
+      {{- end }}
+      secretName: {{ $fullName }}-rpc-tls
   {{- end }}
   rules:
     {{- range .Values.ingressRpc.hosts }}
@@ -72,7 +69,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ include "graphprotocol-node.fullname" $ }}
+                name: {{ $fullName }}
                 port:
                   number: 8020
     {{- end }}
@@ -82,7 +79,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "graphprotocol-node.fullname" . }}-ws
+  name: {{ $fullName }}-ws
   labels:
     {{- include "graphprotocol-node.labels" . | nindent 4 }}
   {{- with .Values.ingressWebsocket.annotations }}
@@ -93,15 +90,13 @@ spec:
   {{- if .Values.ingressWebsocket.ingressClassName }}
   ingressClassName: {{ .Values.ingressWebsocket.ingressClassName }}
   {{- end }}
-  {{- if .Values.ingressWebsocket.tls }}
+  {{- if .Values.ingressWebsocket.tls.enabled }}
   tls:
-    {{- range .Values.ingressWebsocket.tls }}
     - hosts:
-        {{- range .hosts }}
+      {{- range .Values.ingressWebsocket.hosts }}
         - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
+      {{- end }}
+      secretName: {{ $fullName }}-ws-tls
   {{- end }}
   rules:
     {{- range .Values.ingressWebsocket.hosts }}
@@ -112,7 +107,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ include "graphprotocol-node.fullname" $ }}
+                name: {{ $fullName }}
                 port:
                   number: 8001
     {{- end }}
@@ -122,7 +117,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "graphprotocol-node.fullname" . }}-index
+  name: {{ $fullName }}-index
   labels:
     {{- include "graphprotocol-node.labels" . | nindent 4 }}
   {{- with .Values.ingressIndex.annotations }}
@@ -133,15 +128,13 @@ spec:
   {{- if .Values.ingressIndex.ingressClassName }}
   ingressClassName: {{ .Values.ingressIndex.ingressClassName }}
   {{- end }}
-  {{- if .Values.ingressIndex.tls }}
+  {{- if .Values.ingressIndex.tls.enabled }}
   tls:
-    {{- range .Values.ingressIndex.tls }}
     - hosts:
-        {{- range .hosts }}
+      {{- range .Values.ingressIndex.hosts }}
         - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
+      {{- end }}
+      secretName: {{ $fullName }}-index-tls
   {{- end }}
   rules:
     {{- range .Values.ingressIndex.hosts }}
@@ -152,7 +145,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ include "graphprotocol-node.fullname" $ }}
+                name: {{ $fullName }}
                 port:
                   number: 8030
     {{- end }}

--- a/charts/graphprotocol-node/values.yaml
+++ b/charts/graphprotocol-node/values.yaml
@@ -93,11 +93,10 @@ ingress:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
-    # - host: chart-example.local
+    # - chart-example.local
   tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
+    # enabled: true
+    # issuerName: letsencrypt # could also be cloudflare or whatever else, depending on the cert manager used by the cluster
 
 ingressRpc:
   enabled: false
@@ -106,11 +105,10 @@ ingressRpc:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
-    # - host: chart-example.local
+    # - chart-example.local
   tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
+    # enabled: true
+    # issuerName: letsencrypt # could also be cloudflare or whatever else, depending on the cert manager used by the cluster
 
 ingressIndex:
   enabled: false
@@ -119,11 +117,10 @@ ingressIndex:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
-    # - host: chart-example.local
+    # - chart-example.local
   tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
+    # enabled: true
+    # issuerName: letsencrypt # could also be cloudflare or whatever else, depending on the cert manager used by the cluster
 
 ingressWebsocket:
   enabled: false
@@ -132,11 +129,10 @@ ingressWebsocket:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
-    # - host: chart-example.local
+    # - chart-example.local
   tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
+    # enabled: true
+    # issuerName: letsencrypt # could also be cloudflare or whatever else, depending on the cert manager used by the cluster
 
 # error, info, or debug
 logLevel: error


### PR DESCRIPTION
The TLS config that was present in this chart wasn't doing anything, mainly because there was nothing requesting the certs and creating secrets with them.

I've also updated the `appVersion` in `Chart.yaml` since it's used as the default tag for the container image and I'd rather avoid issues if at any point someone doesn't specify a tag and gets a severely outdated image.

All my changes are backwards compatible.