### PR TITLE
TECH-2705 - Patch 2

### DIFF
--- a/charts/graphprotocol-node/templates/certificate.yaml
+++ b/charts/graphprotocol-node/templates/certificate.yaml
@@ -2,9 +2,9 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ .Values.ingress.host }}
+  name: ingress-cert
 spec:
-  secretName: {{ .Values.ingress.host }}-tls
+  secretName: ingress-tls
   duration: 2160h
   renewBefore: 2158h
   issuerRef:
@@ -20,9 +20,9 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ .Values.ingressIndex.host }}
+  name: ingressIndex-cert
 spec:
-  secretName: {{ .Values.ingressIndex.host }}-tls
+  secretName: ingressIndex-tls
   duration: 2160h
   renewBefore: 2158h
   issuerRef:
@@ -38,9 +38,9 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ .Values.ingressRpc.host }}
+  name: ingressRpc-cert
 spec:
-  secretName: {{ .Values.ingressRpc.host }}-tls
+  secretName: ingressRpc-tls
   duration: 2160h
   renewBefore: 2158h
   issuerRef:
@@ -56,9 +56,9 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ .Values.ingressWebsocket.host }}
+  name: ingressWebsocket-cert
 spec:
-  secretName: {{ .Values.ingressWebsocket.host }}-tls
+  secretName: ingressWebsocket-tls
   duration: 2160h
   renewBefore: 2158h
   issuerRef:

--- a/charts/graphprotocol-node/templates/certificate.yaml
+++ b/charts/graphprotocol-node/templates/certificate.yaml
@@ -1,10 +1,11 @@
+{{- $fullName := include "graphprotocol-node.fullname" . -}}
 {{- if and .Values.ingress.enabled .Values.ingress.tls.enabled }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: ingress-cert
+  name: {{ $fullName }}-ingress-cert
 spec:
-  secretName: ingress-tls
+  secretName: {{ $fullName }}-ingress-tls
   duration: 2160h
   renewBefore: 2158h
   issuerRef:
@@ -20,9 +21,9 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: ingressIndex-cert
+  name: {{ $fullName }}-ingressIndex-cert
 spec:
-  secretName: ingressIndex-tls
+  secretName: {{ $fullName }}-ingressIndex-tls
   duration: 2160h
   renewBefore: 2158h
   issuerRef:
@@ -38,9 +39,9 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: ingressRpc-cert
+  name: {{ $fullName }}-ingressRpc-cert
 spec:
-  secretName: ingressRpc-tls
+  secretName: {{ $fullName }}-ingressRpc-tls
   duration: 2160h
   renewBefore: 2158h
   issuerRef:
@@ -56,9 +57,9 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: ingressWebsocket-cert
+  name: {{ $fullName }}-ingressWebsocket-cert
 spec:
-  secretName: ingressWebsocket-tls
+  secretName: {{ $fullName }}-ingressWebsocket-tls
   duration: 2160h
   renewBefore: 2158h
   issuerRef:


### PR DESCRIPTION
There's no `ingress.host` for this chart, there's `ingress.hosts`, so the code was failing do to empty names.

Using `helm template` is not enough to check for something like this since it will seem like the check was successful, you need to dry-run a deployment on the actual cluster.