### PR TITLE
TECH-2705 - Patch 3

### DIFF
--- a/charts/graphprotocol-node/templates/certificate.yaml
+++ b/charts/graphprotocol-node/templates/certificate.yaml
@@ -21,9 +21,9 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ $fullName }}-ingressIndex-cert
+  name: {{ $fullName }}-ingress-index-cert
 spec:
-  secretName: {{ $fullName }}-ingressIndex-tls
+  secretName: {{ $fullName }}-ingress-index-tls
   duration: 2160h
   renewBefore: 2158h
   issuerRef:
@@ -39,9 +39,9 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ $fullName }}-ingressRpc-cert
+  name: {{ $fullName }}-ingress-rpc-cert
 spec:
-  secretName: {{ $fullName }}-ingressRpc-tls
+  secretName: {{ $fullName }}-ingress-rpc-tls
   duration: 2160h
   renewBefore: 2158h
   issuerRef:
@@ -57,9 +57,9 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ $fullName }}-ingressWebsocket-cert
+  name: {{ $fullName }}-ingress-websocket-cert
 spec:
-  secretName: {{ $fullName }}-ingressWebsocket-tls
+  secretName: {{ $fullName }}-ingress-websocket-tls
   duration: 2160h
   renewBefore: 2158h
   issuerRef:


### PR DESCRIPTION
For some reason, you can't use uppercase letters for the name of a `Certificate` resource, the error I got says it's treated like if it were a subdomain and thus it has to comply with RFC 1123... Go figure.

It turns out that doing a dry-run a deployment on the actual cluster is not enough to check whether the updates to the chart work or not. This should be the last one of my patches.