### PR TITLE
Ability to disable volume creation

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.20
+version: 0.0.21
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/common/templates/pvc.yaml
+++ b/charts/common/templates/pvc.yaml
@@ -15,7 +15,11 @@ spec:
   accessModes:
   {{ toYaml . | indent 4 }}
   {{- end }}
-  storageClassName: {{ $fullName }}-{{ $volume.name }}-sc
+  {{- if (eq "-" .storageClass) }}
+    storageClassName: ""
+  {{- else }}
+    storageClassName: {{ $fullName }}-{{ $volume.name }}-sc
+  {{- end }}
   {{- if .resources }}
   resources:
     {{- toYaml .resources | nindent 4 }}

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -31,6 +31,8 @@ deployment:
 #      resources:
 #        requests:
 #          storage: 4Gi
+#      If set to "-", results in storageClassName: "", which disables dynamic provisioning of volume
+#      storageClass: "-"
 #
 #    - name: config
 #      mountPath: /config


### PR DESCRIPTION
When storageClassName is set to `""` K8s will not go ahead with provisioning of new Volume. This is needed when there is already a volume in existence that we want to use.

@OleksandrUA @cristidas @jeannettemcd @sanbotto 