### PR TITLE
Add metricRelabelings to graph serviceMonitor

### DIFF
--- a/charts/graphprotocol-node/Chart.yaml
+++ b/charts/graphprotocol-node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: graphprotocol-node
 description: A Helm chart for Graph Protocol Nodes
 type: application
-version: 0.1.24
+version: 0.1.25
 keywords:
   - graphprotocol
   - ethereum

--- a/charts/graphprotocol-node/templates/servicemonitor.yaml
+++ b/charts/graphprotocol-node/templates/servicemonitor.yaml
@@ -11,4 +11,12 @@ spec:
     {{- include "graphprotocol-node.selectorLabels" . | nindent 6 }}
   endpoints:
   - port: metrics
+    {{- if .Values.monitoring.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- range .Values.monitoring.serviceMonitor.metricRelabelings }}
+      - action: {{ .action }}
+        regex: {{ .regex }}
+        sourceLabels: {{ .sourceLabels | toJson }}
+      {{- end }}
+    {{- end }}
 {{- end -}}

--- a/charts/graphprotocol-node/values.yaml
+++ b/charts/graphprotocol-node/values.yaml
@@ -85,6 +85,11 @@ role: "query-node"
 monitoring:
   enabled: false
   labels: "prometheus"
+  serviceMonitor: {}
+    # metricRelabelings:
+    #   - action: drop
+    #     regex: foo_bar
+    #     sourceLabels: [__name__]
 
 ingress:
   enabled: false


### PR DESCRIPTION
@cristidas @jeannettemcd @SashaTechOps @sanbotto 

This will enable us to drop some unused, noisy metrics coming from Graph to Grafana