### PR TITLE
TECH-4787 - Use a StatefulSet for the Graph index nodes

### DIFF
--- a/charts/graphprotocol-node/Chart.yaml
+++ b/charts/graphprotocol-node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: graphprotocol-node
 description: A Helm chart for Graph Protocol Nodes
 type: application
-version: 0.1.25
+version: 0.2.0
 keywords:
   - graphprotocol
   - ethereum
@@ -12,4 +12,6 @@ sources:
 maintainers:
   - email: dm3ch@dm3ch.net
     name: dm3ch (original author)
-appVersion: v0.33.0
+  - email: engineering@techops.services
+    name: TechOps Services
+appVersion: v0.36.1

--- a/charts/graphprotocol-node/Chart.yaml
+++ b/charts/graphprotocol-node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: graphprotocol-node
 description: A Helm chart for Graph Protocol Nodes
 type: application
-version: 0.2.0
+version: 0.2.1
 keywords:
   - graphprotocol
   - ethereum

--- a/charts/graphprotocol-node/templates/deployment.yaml
+++ b/charts/graphprotocol-node/templates/deployment.yaml
@@ -117,4 +117,5 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ default 10 .Values.terminationGracePeriodSeconds }}
 {{- end }}

--- a/charts/graphprotocol-node/templates/service.yaml
+++ b/charts/graphprotocol-node/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "graphprotocol-node.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}
   annotations:
-  {{-   toYaml . | nindent 4 }}
+  {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/charts/graphprotocol-node/templates/statefulset.yaml
+++ b/charts/graphprotocol-node/templates/statefulset.yaml
@@ -1,14 +1,14 @@
-{{- if eq .Values.role "query-node" }}
+{{- if eq .Values.role "index-node" }}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "graphprotocol-node.fullname" . }}
   labels:
     {{- include "graphprotocol-node.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
-  strategy:
-    type: RollingUpdate
+  serviceName: "{{ include "graphprotocol-node.fullname" . }}-headless"
+  replicas: 1
+  podManagementPolicy: OrderedReady
   selector:
     matchLabels:
       {{- include "graphprotocol-node.selectorLabels" . | nindent 6 }}
@@ -29,7 +29,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
-        - name: wait-for-rta
+        - name: wait-for-psql
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/bin/sh", "-c"]
@@ -43,13 +43,16 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-c", "sleep 60"]
+                command: ["/bin/sh", "-c", "sleep 10"]
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+            {{- /* Index (ingest) node_id should equal BLOCK_INGESTOR env value to work in this mode */}}
+            - name: BLOCK_INGESTOR
+              value: {{ .Values.blockIngestorNodeId | quote }}
             - name: node_id
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
+              value: {{ .Values.blockIngestorNodeId | quote }}
+            - name: GRAPH_LOG
+              value: {{ .Values.logLevel | quote }}
             - name: node_role
               value: {{ .Values.role | quote }}
             - name: GRAPH_KILL_IF_UNRESPONSIVE
@@ -87,6 +90,9 @@ spec:
             - name: graphql-ws
               containerPort: 8001
               protocol: TCP
+            - name: index
+              containerPort: 8030
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /
@@ -98,13 +104,13 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-          - name: config
-            mountPath: "/etc/graph-node"
-            readOnly: true
+            - name: config
+              mountPath: "/etc/graph-node"
+              readOnly: true
       volumes:
-      - name: config
-        secret:
-          secretName: {{ include "graphprotocol-node.fullname" . }}
+        - name: config
+          secret:
+            secretName: {{ include "graphprotocol-node.fullname" . }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/graphprotocol-node/values.yaml
+++ b/charts/graphprotocol-node/values.yaml
@@ -146,3 +146,6 @@ logLevel: error
 env:
   GRAPH_GRAPHQL_MAX_FIRST: 1000
   EXPERIMENTAL_SUBGRAPH_VERSION_SWITCHING_MODE: instant
+
+# If you need to increase the default of 10 seconds, use this:
+# terminationGracePeriodSeconds: 30


### PR DESCRIPTION
We're now using a different approach for the index deployment, one that guarantees that the existing pod will be fully removed before a new one can be created. This will prevent errors that arise from having 2 nodes indexing the same subgraph at the same time, which is an error than can happen if the pod overlap happens for less than a minute.

This has already been tested and it's working as expected. The only important thing to consider is that it might be best to delete the Helm deployment and creating it again from scratch instead of updating it, as I've seen issues while updating the index because the deployment that had been created previously was still available and scheduling pods.