### PR TITLE
Ability to specify more than one ServiceMonitor

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "yaml.validate": false,
+    "[yaml]": {
+        "editor.formatOnSave": false
+    }
+} 

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.38
+version: 0.0.39
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.39
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/common/templates/servicemonitor.yaml
+++ b/charts/common/templates/servicemonitor.yaml
@@ -1,52 +1,55 @@
-{{- if and .Values.serviceMonitor.enabled .Values.service }}
+{{- if and .Values.serviceMonitors.enabled .Values.service }}
+{{- range .Values.serviceMonitors.monitors }}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "common.fullname" . }}
-  {{- if .Values.serviceMonitor.namespace }}
-  namespace: {{ .Values.serviceMonitor.namespace }}
+  name: {{ include "common.fullname" . }}-{{ .name }}
+  {{- if $.Values.serviceMonitors.namespace }}
+  namespace: {{ $.Values.serviceMonitors.namespace }}
   {{- else }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ $.Release.Namespace }}
   {{- end }}
   labels:
-    {{- include "common.labels" . | nindent 4 }}
-    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- include "common.labels" $ | nindent 4 }}
+    {{- with $.Values.serviceMonitors.additionalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   endpoints:
-    - port: {{ .Values.serviceMonitor.port }}
-      {{- if .Values.serviceMonitor.path }}
-      path: {{ .Values.serviceMonitor.path }}
+    - port: {{ .port }}
+      {{- if .path }}
+      path: {{ .path }}
       {{- end }}
-      {{- if .Values.serviceMonitor.interval }}
-      interval: {{ .Values.serviceMonitor.interval }}
+      {{- if .interval }}
+      interval: {{ .interval }}
       {{- end }}
-      {{- if .Values.serviceMonitor.scrapeTimeout }}
-      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      {{- if .scrapeTimeout }}
+      scrapeTimeout: {{ .scrapeTimeout }}
       {{- end }}
-      {{- if .Values.serviceMonitor.scheme }}
-      scheme: {{ .Values.serviceMonitor.scheme }}
+      {{- if .scheme }}
+      scheme: {{ .scheme }}
       {{- end }}
-      {{- with .Values.serviceMonitor.tlsConfig }}
+      {{- with .tlsConfig }}
       tlsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.serviceMonitor.relabelings }}
+      {{- with .relabelings }}
       relabelings:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.serviceMonitor.metricRelabelings }}
+      {{- with .metricRelabelings }}
       metricRelabelings:
         {{- toYaml . | nindent 8 }}
       {{- end }}
   selector:
     matchLabels:
-      {{- include "common.selectorLabels" . | nindent 6 }}
+      {{- include "common.selectorLabels" $ | nindent 6 }}
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
-  {{- with .Values.serviceMonitor.spec }}
+      - {{ $.Release.Namespace }}
+  {{- with .spec }}
   {{- toYaml . | nindent 2 }}
   {{- end }}
+{{- end }}
 {{- end }} 

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -297,29 +297,31 @@ env:
 #     name: example-db
 #     parameter_name: DB_PASSWORD
 
-serviceMonitor:
+serviceMonitors:
   enabled: false
-  # The label used by the Prometheus Operator to discover ServiceMonitors
-  additionalLabels: {}
-    # release: prometheus-operator
-  # Namespace where ServiceMonitor resource will be created
-  namespace: ""
-  # Interval at which metrics should be scraped
-  interval: 30s
-  # Timeout for scraping
-  scrapeTimeout: 10s
-  # The path at which metrics are exposed
-  path: /metrics
-  # The port name or number to scrape metrics from
-  port: metrics
-  # Additional relabeling configurations
-  relabelings: []
-  # Additional metric relabeling configurations
-  metricRelabelings: []
-  # Scheme to use for scraping
-  scheme: http
-  # TLS configuration for scraping
-  tlsConfig: {}
-    # insecureSkipVerify: true
-  # Additional ServiceMonitor specifications
-  spec: {}
+  monitors:
+    - name: service1
+      # The label used by the Prometheus Operator to discover ServiceMonitors
+      additionalLabels: {}
+        # release: prometheus-operator
+      # Namespace where ServiceMonitor resource will be created
+      namespace: ""
+      # Interval at which metrics should be scraped
+      interval: 30s
+      # Timeout for scraping
+      scrapeTimeout: 10s
+      # The path at which metrics are exposed
+      path: /metrics
+      # The port name or number to scrape metrics from
+      port: metrics
+      # Additional relabeling configurations
+      relabelings: []
+      # Additional metric relabeling configurations
+      metricRelabelings: []
+      # Scheme to use for scraping
+      scheme: http
+      # TLS configuration for scraping
+      tlsConfig: {}
+        # insecureSkipVerify: true
+      # Additional ServiceMonitor specifications
+      spec: {}


### PR DESCRIPTION
- add vscode yaml linting config to ignore helm templates
- incrementing the minor version cos it's a breaking change for other apps that have ServiceMonitor turned on