### PR TITLE
Fix serviceAccountName not being set when create=false

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -55,5 +55,5 @@ app.kubernetes.io/serviceName: {{ include "common.fullname" .}}
 Create the name of the service account to use
 */}}
 {{- define "common.serviceAccountName" -}}
-{{- default "default" .Values.service.name }}
+{{- default "default" .Values.serviceAccount.name }}
 {{- end }}

--- a/charts/common/templates/deployment.yaml
+++ b/charts/common/templates/deployment.yaml
@@ -77,7 +77,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.serviceAccount.create }}
+      {{- if .Values.serviceAccount.name }}
       serviceAccountName: {{ include "common.serviceAccountName" . }}
       {{- end }}
       securityContext:


### PR DESCRIPTION
## Problem

Deployments using `serviceAccount.create: false` with an existing service account name were incorrectly using the `default` service account instead of the specified one.

## Root Cause

Two bugs in the common chart:

1. **`_helpers.tpl`** - `common.serviceAccountName` helper used `.Values.service.name` instead of `.Values.serviceAccount.name`

2. **`deployment.yaml`** - Only set `serviceAccountName` when `serviceAccount.create` was true:
   ```yaml
   {{- if .Values.serviceAccount.create }}
   serviceAccountName: {{ include "common.serviceAccountName" . }}
   {{- end }}
   ```

## Fix

1. Fixed helper to use correct path: `.Values.serviceAccount.name`
2. Changed condition to check `serviceAccount.name` instead of `serviceAccount.create`

Now `serviceAccountName` is set whenever a name is provided, regardless of whether the chart creates the SA or uses an existing one.

## Test Plan

- [ ] Deploy with `serviceAccount.create: true` → SA created and used
- [ ] Deploy with `serviceAccount.create: false, name: existing-sa` → existing SA used