### PR TITLE
feat(common): add statefulset template alongside deployment

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/common/templates/pvc.yaml
+++ b/charts/common/templates/pvc.yaml
@@ -1,5 +1,6 @@
 {{- $fullName := include "common.fullname" . -}}
-{{- range $volume := .Values.deployment.volumes | default list }}
+{{- $allVolumes := concat (.Values.deployment.volumes | default list) (.Values.statefulset.volumes | default list) }}
+{{- range $volume := $allVolumes }}
 {{- if and $volume.name (not $volume.emptyDir) (not $volume.configMap) (not $volume.secret) }}
 ---
 apiVersion: v1

--- a/charts/common/templates/statefulset.yaml
+++ b/charts/common/templates/statefulset.yaml
@@ -1,0 +1,268 @@
+{{- if .Values.statefulset.enabled }}
+{{- $fullName := include "common.fullname" . -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "common.fullname" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  serviceName: {{ .Values.statefulset.serviceName | default (include "common.fullname" .) | quote }}
+  podManagementPolicy: {{ .Values.statefulset.podManagementPolicy | default "OrderedReady" }}
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "common.selectorLabels" . | nindent 6 }}
+      {{- with .Values.selectorLabels }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "common.selectorLabels" . | nindent 8 }}
+        {{- with .Values.selectorLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- if .Values.statefulset.initContainers }}
+      initContainers:
+        {{- range .Values.statefulset.initContainers }}
+        - name: {{ .name }}
+          image: {{ .image }}
+          {{- if .command }}
+          command:
+            {{ toYaml .command | nindent 12 }}
+          {{- end }}
+          {{- if .restartPolicy }}
+          restartPolicy: {{ .restartPolicy }}
+          {{- end }}
+          {{- if .args }}
+          args:
+            {{ toYaml .args | nindent 12 }}
+          {{- end }}
+          {{- if .env }}
+          env:
+            {{- range $k, $v := .env }}
+            - name: {{ $k | quote }}
+            {{- if eq $v.type "kv" }}
+              value: {{ $v.value | quote }}
+            {{- else if eq $v.type "parameterStore" }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ $fullName }}-{{ $v.name }}"
+                  key: "{{ $fullName }}-{{ $v.name }}"
+            {{- else if eq $v.type "configmapRef" }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $v.name | quote }}
+                  key: {{ $v.key | quote }}
+            {{- else if eq $v.type "secret" }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $v.name | quote }}
+                  key: {{ $v.key | quote }}
+            {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- if .volumeMounts }}
+          volumeMounts:
+            {{- range .volumeMounts }}
+            - name: {{ $fullName }}-{{ .name }}-volume
+              mountPath: {{ .mountPath }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "common.serviceAccountName" . }}
+      {{- end }}
+      {{- if .Values.statefulset.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.statefulset.terminationGracePeriodSeconds }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.statefulset.volumes }}
+      volumes:
+        {{- range $volume := .Values.statefulset.volumes }}
+        - name: {{ $fullName }}-{{ $volume.name }}-volume
+          {{- if $volume.emptyDir }}
+          emptyDir:
+            {{- if $volume.emptyDir.sizeLimit }}
+            sizeLimit: {{ $volume.emptyDir.sizeLimit }}
+            {{- end }}
+          {{- else if $volume.configMap }}
+          configMap:
+            name: {{ $volume.configMap.name }}
+            {{- if $volume.configMap.items }}
+            items:
+              {{- range $item := $volume.configMap.items }}
+              - key: {{ $item.key }}
+                path: {{ $item.path }}
+              {{- end }}
+            {{- end }}
+          {{- else if $volume.secret }}
+          secret:
+            secretName: {{ $volume.secret.secretName }}
+            {{- if $volume.secret.items }}
+            items:
+              {{- range $item := $volume.secret.items }}
+              - key: {{ $item.key }}
+                path: {{ $item.path }}
+              {{- end }}
+            {{- end }}
+          {{- else }}
+          persistentVolumeClaim:
+            claimName: {{ $fullName }}-{{ $volume.name }}-pvc
+          {{- end }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: {{ include "common.fullname" . }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- if .Values.statefulset.lifecycle }}
+          lifecycle:
+            {{- toYaml .Values.statefulset.lifecycle | nindent 12 }}
+          {{- end }}
+          {{- if .Values.statefulset.volumes }}
+          volumeMounts:
+            {{- range $volume := .Values.statefulset.volumes }}
+            - name: {{ $fullName }}-{{ $volume.name }}-volume
+              mountPath: {{ $volume.mountPath }}
+              {{- if or $volume.configMap $volume.secret }}
+              readOnly: true
+              {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.command }}
+          command:
+            {{ toYaml .Values.command | nindent 12 }}
+          {{- end }}
+          {{- if .Values.args }}
+          args:
+            {{ toYaml .Values.args | nindent 12 }}
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.service.containerPort }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.containerPort }}
+              protocol: TCP
+          {{- else if .Values.statefulset.ports }}
+          ports:
+            {{- range .Values.statefulset.ports }}
+            - name: {{ .name }}
+              containerPort: {{ .containerPort }}
+              protocol: {{ .protocol }}
+            {{- end }}
+          {{- end }}
+          env:
+            {{- range $k, $v := .Values.env }}
+            - name: {{ $k | quote }}
+            {{- if eq $v.type "kv" }}
+              value: {{ $v.value | quote }}
+            {{- else if eq $v.type "parameterStore" }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ $fullName }}-{{ $v.name }}"
+                  key: "{{ $fullName }}-{{ $v.name }}"
+            {{- else if eq $v.type "configmapRef" }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $v.name | quote }}
+                  key: {{ $v.key | quote }}
+            {{- else if eq $v.type "secret" }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $v.name | quote }}
+                  key: {{ $v.key | quote }}
+            {{- end }}
+            {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+
+        {{- if .Values.sidecars }}
+        {{- range .Values.sidecars }}
+        - name: {{ .name }}
+          image: "{{ .image.repository }}:{{ .image.tag }}"
+          {{- if .volumeMounts }}
+          volumeMounts:
+            {{- range .volumeMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+            {{- end }}
+          {{- end }}
+          {{- if .ports }}
+          ports:
+            {{- range .ports }}
+            - name: {{ .name }}
+              containerPort: {{ .containerPort }}
+              protocol: {{ .protocol | default "TCP" }}
+            {{- end }}
+          {{- end }}
+          {{- if .args }}
+          args:
+            {{- toYaml .args | nindent 12 }}
+          {{- end }}
+          {{- if .env }}
+          env:
+            {{- range $k, $v := .env }}
+            - name: {{ $k | quote }}
+              {{- if eq $v.type "kv" }}
+              value: {{ $v.value | quote }}
+              {{- else if eq $v.type "parameterStore" }}
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ $fullName }}-{{ $v.name }}"
+                  key: "{{ $fullName }}-{{ $v.name }}"
+              {{- else if eq $v.type "configmapRef" }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $v.name | quote }}
+                  key: {{ $v.key | quote }}
+              {{- else if eq $v.type "secret" }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $v.name | quote }}
+                  key: {{ $v.key | quote }}
+              {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- if .resources }}
+          resources:
+            {{- toYaml .resources | nindent 12 }}
+          {{- end }}
+        {{- end }}
+        {{- end }}
+
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/common/templates/storageclass.yaml
+++ b/charts/common/templates/storageclass.yaml
@@ -1,5 +1,6 @@
 {{- $fullName := include "common.fullname" . -}}
-{{- range $volume := .Values.deployment.volumes | default list }}
+{{- $allVolumes := concat (.Values.deployment.volumes | default list) (.Values.statefulset.volumes | default list) }}
+{{- range $volume := $allVolumes }}
 {{- if and $volume.name (not $volume.emptyDir) (not $volume.configMap) (not $volume.secret) }}
 ---
 apiVersion: storage.k8s.io/v1

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -104,6 +104,36 @@ deployment:
 #        requests:
 #          storage: 4Gi
 
+# StatefulSet — alternative to `deployment` for stateful single-replica or
+# replica-pinned workloads (per-pod stable network ID, strict serial pod
+# replacement, optional per-replica volumes via volumeClaimTemplates in a
+# future iteration). Mutually exclusive with `deployment.enabled` — only
+# one of the two should be true.
+#
+# Volumes use the same shape as `deployment.volumes` and are realised via
+# the chart's existing pvc.yaml / storageclass.yaml templates (one PVC per
+# release, NOT per replica). Use this mode when migrating an existing
+# Deployment+PVC pair to a StatefulSet without re-provisioning storage.
+statefulset:
+  enabled: false
+  # Headless Service to back the StatefulSet's stable network identity.
+  # Defaults to the chart's fullname if unset.
+  serviceName: ""
+  # OrderedReady (default) — pods come up sequentially, terminate in reverse.
+  # Parallel — all pods at once (rare; useful when ordering doesn't matter).
+  podManagementPolicy: OrderedReady
+  terminationGracePeriodSeconds: 60
+  # Container lifecycle hooks (e.g., preStop sleep so kubelet finishes
+  # unmount before the controller starts attach on the new pod).
+  lifecycle: {}
+  #   preStop:
+  #     exec:
+  #       command: ["sh", "-c", "sleep 5"]
+  initContainers: []
+  ports: []
+  volumes: []
+  # Same shape as deployment.volumes — see above for examples.
+
 cronjob:
   enabled: false
   jobs: []


### PR DESCRIPTION
## Summary
Adds opt-in StatefulSet mode to the common chart. Mirrors `deployment.yaml` 1:1 — only `kind`, `serviceName`, `podManagementPolicy`, `terminationGracePeriodSeconds`, and container `lifecycle` are new.

| Use case | Mode |
|----------|------|
| Stateless web/worker, multiple replicas, rolling deploys | `deployment.enabled: true` (existing — unchanged) |
| **Stateful single-replica with persistent state, RWO PVC** | **`statefulset.enabled: true` (new)** |

First consumer is raita-bot (Discord daemon with EBS-backed Hermes profile). Multi-Attach errors during deploys + cleaner serial pod replacement semantics motivated the change.

## What's new
- `templates/statefulset.yaml` — gated on `statefulset.enabled`. Surfaces \`terminationGracePeriodSeconds\` + container \`lifecycle\` hooks (preStop sleep, etc.) which the deployment template doesn't currently expose.
- `templates/pvc.yaml` + `templates/storageclass.yaml` — now iterate the **union** of \`deployment.volumes\` and \`statefulset.volumes\` so PVCs/StorageClasses are created regardless of which workload kind is enabled.
- `values.yaml` — new \`statefulset:\` section, fully documented inline.
- Chart bump 0.2.3 → 0.3.0 (minor: additive, backward compatible).

## PVC name preservation = seamless migration
The PVC name pattern (`<fullname>-<volume>-pvc`) is identical between the two templates. A consumer can flip from Deployment to StatefulSet on the same Helm release without re-provisioning storage — the StatefulSet binds to the existing PVC.

For raita-bot specifically:
- Existing PVC: \`raita-bot-prod-common-hermes-home-pvc\`
- After flip: same PVC, same EBS volume, no data migration needed

## Migration sequence (for the consumer)
1. \`helm upgrade ... --set deployment.enabled=false --set statefulset.enabled=true ...\`
2. Helm replaces the Deployment with a StatefulSet; PVC is unchanged.
3. New StatefulSet pod (\`<fullname>-0\`) attaches to the same EBS volume.

## Out of scope
- **\`volumeClaimTemplates\` (per-replica volumes)** — intentionally not in this iteration. The multi-replica + per-replica-PVC story needs more thought (PVC lifecycle on scale-down, naming, etc.). Today's StatefulSet mode supports the single-replica migration case, which is what raita-bot needs.
- Multi-replica StatefulSets are technically supported but will share the single PVC (so all replicas would mount-fail under RWO). For multi-replica, wait for the volumeClaimTemplates follow-up or use the existing Deployment mode.

## Test plan
- [x] \`helm template\` renders cleanly with \`statefulset.enabled=true\` and a raita-bot-like values set
- [x] PVC name matches what existing Deployment-based releases already use
- [x] Pre-existing chart lint error (\`templates/tests/test-connection.yaml\` referencing undefined \`service.port\`) is unchanged — not introduced here
- [ ] Reviewer: render with each existing service's values to confirm no behavioural change when \`statefulset.enabled\` is left at its default (false)

## Companion PR
- raita-bot repo: [KeeperHub/raita-bot#6](https://github.com/KeeperHub/raita-bot/pull/6) — flips raita-bot to StatefulSet once this lands and the chart is published.